### PR TITLE
force compile roseus messages

### DIFF
--- a/dxl_armed_turtlebot/CMakeLists.txt
+++ b/dxl_armed_turtlebot/CMakeLists.txt
@@ -5,4 +5,6 @@ find_package(catkin REQUIRED COMPONENTS kobuki_msgs control_msgs move_base_msgs 
 
 catkin_package()
 
+_generate_eus_dep_msgs(${PROJECT_NAME})
+
 add_rostest(test/test-dxl-armed-turtlebot.test)


### PR DESCRIPTION
since travis passed, we do not need this code, but it seems sometimes we need to manually generate roseus messages.