### PR TITLE
receive rest arguments in update-robot-staet

### DIFF
--- a/dxl_armed_turtlebot/euslisp/dxl-armed-turtlebot-interface.l
+++ b/dxl_armed_turtlebot/euslisp/dxl-armed-turtlebot-interface.l
@@ -136,7 +136,7 @@
    (make-coords :rot (send self :imurot)))
   (:power-system-vector () (cdr (assoc :power-system robot-state)))
   (:update-robot-state
-   ()
+   (&rest args)
    (prog1
        (send-super :update-robot-state)
      (if (send self :simulation-modep)


### PR DESCRIPTION
See https://github.com/jsk-enshu/robot-programming/issues/15.

エラーはなくなりましたが，別のwarningが出ていますが，これは大丈夫でしょうか．

``` lisp
10.irteusgl$ send *ri* :state
:simulate should be defined in lower class
:simulate should be defined in lower class
nil
11.irteusgl$ send *ri* :angle-vector #f(0 0 0 0 0 0 0) 1000
:simulate should be defined in lower class
:simulate should be defined in lower class
#f(0.0 0.0 0.0 0.0 0.0 0.0 0.0)
```
