### PR TITLE
Add hsi_color_filter tempolarily.

### DIFF
--- a/dxl_armed_turtlebot/launch/hsi_color_filter.launch
+++ b/dxl_armed_turtlebot/launch/hsi_color_filter.launch
@@ -1,0 +1,68 @@
+<!-- -*- mode: xml -*- -->
+<launch>
+  <!--
+  ;; This launch file is copied from jsk_pcl_ros/launch.
+  ;; To use this,
+  $ roslaunch openni_launch openni.launch    ;; start kinect camera
+  $ rosrun rqt_reconfigure rqt_reconfigure   ;; parameter settings
+  $ roslaunch jsk_pcl_ros hsi_color_filter.launch DEFAULT_NAMESPACE:=/camera/depth_registered INPUT:=points
+  ;; subscribe camera/depth_registered/hsi_output
+  ;; subscribe tf and find /target
+  -->
+  <arg name="INPUT" default="hsi_input"/>
+  <arg name="OUTPUT" default="hsi_output"/>
+  <arg name="CENTROID_FRAME" default="target"/>
+  <arg name="DEFAULT_NAMESPACE" default="HSI_color_filter"/>
+
+  <arg name="h_max" default="127" />
+  <arg name="h_min" default="-128" />
+  <arg name="s_max" default="255" />
+  <arg name="s_min" default="0" />
+  <arg name="v_max" default="255" />
+  <arg name="v_min" default="0" />
+
+  <arg name="create_manager" default="true" />
+  <arg name="manager" default="hsi_filter_manager" />
+
+  <group ns="$(arg DEFAULT_NAMESPACE)">
+    <node if="$(arg create_manager)"
+          pkg="nodelet" type="nodelet" name="$(arg manager)"
+          args="manager" output="screen"/>
+
+    <node pkg="nodelet" type="nodelet" name="hsi_filter"
+          args="load jsk_pcl/HSIColorFilter $(arg manager)" output="screen">
+      <remap from="~input" to="$(arg INPUT)" />
+      <remap from="~output" to="$(arg OUTPUT)" />
+      <rosparam>
+        use_indices: false
+      </rosparam>
+      <param name="h_limit_max" value="$(arg h_max)" />
+      <param name="h_limit_min" value="$(arg h_min)" />
+      <param name="s_limit_max" value="$(arg s_max)" />
+      <param name="s_limit_min" value="$(arg s_min)" />
+      <param name="v_limit_max" value="$(arg v_max)" />
+      <param name="v_limit_min" value="$(arg v_min)" />
+    </node>
+    <node pkg="nodelet" type="nodelet" name="euclidean_clustering"
+          args="load jsk_pcl/EuclideanClustering $(arg manager)" output="screen">
+      <remap from="~input" to="$(arg OUTPUT)" />
+      <rosparam>
+        tolerance: 0.02
+        min_size: 100
+      </rosparam>
+    </node>
+
+    <node pkg="nodelet" type="nodelet"
+          name="cluster_decomposer"
+          args="load jsk_pcl/ClusterPointIndicesDecomposerZAxis $(arg manager)"
+          output="screen" clear_params="true">
+      <remap from="~input" to="$(arg OUTPUT)" />
+      <remap from="~target" to="euclidean_clustering/output" />
+      <rosparam>
+      </rosparam>
+    </node>
+
+
+  </group>
+
+</launch>


### PR DESCRIPTION
Add hsi_color_filter tempolarily. 
jsk_pcl_ros already distributes launch file:
https://github.com/jsk-ros-pkg/jsk_recognition/pull/433

After jsk_pcl_ros's deb starts to include these launch files, 
I'll remove this hsi_color_filter.launch from this repository.
