### PR TITLE
Update ps3joy teleop launch to reduce velocity and use indigo

### DIFF
--- a/dxl_armed_turtlebot/launch/dxl_armed_turtlebot_bringup.launch
+++ b/dxl_armed_turtlebot/launch/dxl_armed_turtlebot_bringup.launch
@@ -15,7 +15,7 @@
   <include file="$(find turtlebot_bringup)/launch/3dsensor.launch">
     <arg name="3d_sensor" default="kinect" />
   </include>
-  <include file="$(find turtlebot_teleop)/launch/ps3_teleop.launch"
+  <include file="$(find dxl_armed_turtlebot)/launch/turtlebot_joystick_teleop.launch"
            if="$(arg RUN_PS3JOY)"/>
   <!-- <include file="$(find turtlebot_rviz_launchers)/launch/view_robot.launch"/> -->
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find turtlebot_rviz_launchers)/rviz/robot.rviz" respawn="true"

--- a/dxl_armed_turtlebot/scripts/ps3joy
+++ b/dxl_armed_turtlebot/scripts/ps3joy
@@ -14,7 +14,8 @@
 
 #. /opt/ros/electric/setup.sh
 #. /opt/ros/groovy/setup.sh
-. /opt/ros/hydro/setup.sh
+#. /opt/ros/hydro/setup.sh
+. /opt/ros/indigo/setup.sh
 export ROS_HOME=/root
 
 # path to daemon


### PR DESCRIPTION
Update ps3joy teleop launch to reduce velocity and use indigo.