### PR TITLE
fix gripper-controller

### DIFF
--- a/dynamixel_7dof_arm/euslisp/dxl-7dof-arm-interface-common.l
+++ b/dynamixel_7dof_arm/euslisp/dxl-7dof-arm-interface-common.l
@@ -100,8 +100,8 @@
    )
   (:default-controller
    ()
-   (send self :fullbody-controller)
-   ;;(append (send self :fullbody-controller) (send self :gripper-controller))
+   ;;(send self :fullbody-controller)
+   (append (send self :fullbody-controller) (send self :gripper-controller))
    )
   ;; raw dynamixel command
   ;;   TODO : define these methods by considering pr2eus?
@@ -166,8 +166,9 @@
   (:start-grasp
    (&optional (arm :arm) &key ((:gain g) 0.5) ((:objects objs) objects))
    "Start grasp mode."
-   (send self :set-compliance-slope 7 1023)
-   (send self :set-torque-limit 7 g)
+   (unless (send self :simulation-modep)
+     (send self :set-compliance-slope 7 1023)
+     (send self :set-torque-limit 7 g))
    (send robot :gripper arm :angle-vector
          (send-all (send robot :gripper arm :joint-list) :min-angle))
    (send self :angle-vector (send robot :angle-vector) 1000 :gripper-controller)
@@ -185,8 +186,9 @@
    (send robot :gripper arm :angle-vector
          (send-all (send robot :gripper arm :joint-list) :max-angle))
    (send self :angle-vector (send robot :angle-vector) 1000 :gripper-controller)
-   (send self :set-compliance-slope 7 32)
-   (send self :set-torque-limit 7 1.0)
+   (unless (send self :simulation-modep)
+     (send self :set-compliance-slope 7 32)
+     (send self :set-torque-limit 7 1.0))
    (send self :wait-interpolation :gripper-controller)
    )
   )


### PR DESCRIPTION
#149の修正をしました

1. gripperでもcontroller-action-clientを使いように変更(何故かコメントアウトされていた)
2. simulator modeでは`:set-compliance-slope`と`:set-torque-limit`しないように変更

```
31.irteusgl$ send *dxl-armed-turtlebot* :gripper :arm :angle-vector #f(50)
#f(50.0)
32.irteusgl$ send *ri* :angle-vector (send *dxl-armed-turtlebot* :angle-vector) 1000 :gripper-controller
:simulate should be defined in lower class
:simulate should be defined in lower class
#f(0.0 0.0 0.0 0.0 0.0 0.0 50.0)
33.irteusgl$ send *ri* :start-grasp
:simulate should be defined in lower class
:simulate should be defined in lower class
:simulate should be defined in lower class
:simulate should be defined in lower class
:simulate should be defined in lower class
:simulate should be defined in lower class
(nil nil)
```