### PR TITLE
add dynamixel_3dof_arms

### DIFF
--- a/dynamixel_3dof_arm/CMakeLists.txt
+++ b/dynamixel_3dof_arm/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(dynamixel_3dof_arm)
+
+find_package(catkin REQUIRED COMPONENTS dynamixel_controllers roseus rostest) # add roseus to gen messages
+
+catkin_package()
+
+add_rostest(test/test-dxl-7dof-arm.test)

--- a/dynamixel_3dof_arm/config/dynamixel_joint_controllers.yaml
+++ b/dynamixel_3dof_arm/config/dynamixel_joint_controllers.yaml
@@ -1,0 +1,110 @@
+arm_j1_controller:
+    controller:
+        package: dynamixel_controllers
+        module: joint_position_controller
+        type: JointPositionController
+    joint_name: arm_joint1
+    joint_speed: 2.0
+    motor:
+        id: 1
+        init: 512
+        min: 0
+        max: 1023
+
+arm_j2_controller:
+    controller:
+        package: dynamixel_controllers
+        module: joint_position_controller
+        type: JointPositionController
+    joint_name: arm_joint2
+    joint_speed: 2.0
+    motor:
+        id: 2
+        init: 512
+        min: 0
+        max: 1023
+
+arm_j3_controller:
+    controller:
+        package: dynamixel_controllers
+        module: joint_position_controller
+        type: JointPositionController
+    joint_name: arm_joint3
+    joint_speed: 2.0
+    motor:
+        id: 3
+        init: 512
+        min: 0
+        max: 1023
+
+arm_j4_controller:
+    controller:
+        package: dynamixel_controllers
+        module: joint_position_controller
+        type: JointPositionController
+    joint_name: arm_joint4
+    joint_speed: 2.0
+    motor:
+        id: 4
+        init: 512
+        min: 0
+        max: 1023
+
+arm_j5_controller:
+    controller:
+        package: dynamixel_controllers
+        module: joint_position_controller
+        type: JointPositionController
+    joint_name: arm_joint5
+    joint_speed: 2.0
+    motor:
+        id: 5
+        init: 512
+        min: 0
+        max: 1023
+
+arm_j6_controller:
+    controller:
+        package: dynamixel_controllers
+        module: joint_position_controller
+        type: JointPositionController
+    joint_name: arm_joint6
+    joint_speed: 2.0
+    motor:
+        id: 6
+        init: 512
+        min: 0
+        max: 1023
+
+arm_j7_controller:
+    controller:
+        package: dynamixel_controllers
+        module: joint_position_controller
+        type: JointPositionController
+    joint_name: arm_joint7
+    joint_speed: 2.0
+    motor:
+        id: 7
+        init: 512
+        min: 0
+        max: 1023
+
+fullbody_controller:
+   controller:
+       package: dynamixel_controllers
+       module: joint_trajectory_action_controller
+       type: JointTrajectoryActionController
+   joint_trajectory_action_node:
+       min_velocity: 0.25
+       constraints:
+           goal_time: 0.0
+
+gripper_controller:
+   controller:
+       package: dynamixel_controllers
+       module: joint_trajectory_action_controller
+       type: JointTrajectoryActionController
+   joint_trajectory_action_node:
+       min_velocity: 0.25
+       constraints:
+           goal_time: 0.0

--- a/dynamixel_3dof_arm/euslisp/dxl-3dof-arm-interface-common.l
+++ b/dynamixel_3dof_arm/euslisp/dxl-3dof-arm-interface-common.l
@@ -1,0 +1,194 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; 3dof アームロボットのrobot-interfaceクラスのメソッド定義部
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(ros::load-ros-manifest "dynamixel_controllers")
+
+(defun get-method-list-for-dxl-3dof-arm-interface ()
+'(
+  ;; サービスのwaitやsubscribeコールバック関数設定を行う初期化メソッド
+  (:initialize-arm-robot-ros
+   ()
+   ;; subscriber
+   (dotimes (i (length (send robot :angle-vector)))
+     (ros::subscribe
+      (format nil "/arm_j~d_controller/state" (1+ i))
+      dynamixel_msgs::JointState
+      #'send self :dynamixel-motor-states-callback :groupname groupname))
+   (unless (send self :simulation-modep)
+   ;; services
+     (dotimes (i (length (send robot :angle-vector)))
+       (ros::wait-for-service
+        (format nil "/arm_j~d_controller/set_compliance_slope" (1+ i)))
+       (ros::wait-for-service
+        (format nil "/arm_j~d_controller/torque_enable" (1+ i)))
+       (ros::wait-for-service
+        (format nil "/arm_j~d_controller/set_torque_limit" (1+ i)))
+       )
+     )
+   ;; define actions
+   (dolist (l (list
+               (cons :fullbody-controller "fullbody_controller/follow_joint_trajectory")
+               (cons :gripper-controller "gripper_controller/follow_joint_trajectory")
+               ))
+     (let ((type (car l))
+           (name (cdr l))
+           action)
+       (setq action (find-if #'(lambda (ac) (string= name (send ac :name)))
+                             controller-actions))
+       (setf (gethash type controller-table)
+             (if action
+                 (list action)
+               (list (instance ros::simple-action-client :init
+                               name
+                               control_msgs::followjointtrajectoryaction
+                               :groupname groupname))))
+       ))
+   )
+  ;; TODO
+  ;;  This method is tempolary code.
+  ;;  dynamixel_controller_manager should publish /dxl_3dof_arm/joint_states
+  (:dynamixel-motor-states-callback
+   (msg)
+   ;; for initialize
+   (dolist (key '(:position :velocity :effort :name))
+     ;; neglect /joint_states from turtlebot
+     (unless (and (cdr (assoc key robot-state))
+                  (= (length (send robot :angle-vector)) (length (cdr (assoc key robot-state)))))
+       (send self :set-robot-state1 key
+             (if (eq key :name)
+                 (make-list (length (send robot :angle-vector)))
+               (instantiate float-vector (length (send robot :angle-vector)))))))
+   ;; update values
+   (dolist (key '(:position :velocity :effort :name))
+     (setf (elt (cdr (assoc key robot-state)) (1- (elt (send msg :motor_ids) 0)))
+           (case key
+             (:position (send msg :current_pos))
+             (:name (send msg :name))
+             (:velocity (send msg :velocity))
+             (:effort (send msg :load)))
+           )
+     )
+   )
+  (:fullbody-controller
+   ()
+   (list
+    (list
+     (cons :controller-action "fullbody_controller/follow_joint_trajectory")
+     (cons :controller-state "fullbody_controller/state")
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (mapcar #'(lambda (n) (if (symbolp n) (symbol-name n) n))
+                                (send-all
+                                 (remove-if #'(lambda (x)
+                                                (member x (send robot :gripper :arm :joint-list)))
+                                            (send robot :joint-list))
+                                 :name)
+                                )))
+    )
+   )
+  (:gripper-controller
+   ()
+   (list
+    (list
+     (cons :controller-action "gripper_controller/follow_joint_trajectory")
+     (cons :controller-state "gripper_controller/state")
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (mapcar #'(lambda (n) (if (symbolp n) (symbol-name n) n))
+                                (send-all (send robot :gripper :arm :joint-list) :name)
+                                )))
+    )
+   )
+  (:default-controller
+   ()
+   (send self :fullbody-controller)
+   ;;(append (send self :fullbody-controller) (send self :gripper-controller))
+   )
+  ;; raw dynamixel command
+  ;;   TODO : define these methods by considering pr2eus?
+  ;; for controller parameters, please see:
+  ;;  http://www.besttechnology.co.jp/modules/knowledge/?Dynamixel%E3%82%B3%E3%83%B3%E3%83%88%E3%83%AD%E3%83%BC%E3%83%AB%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB%28DX%2CRX%2CAX%E3%82%B7%E3%83%AA%E3%83%BC%E3%82%BA%E7%94%A8%29#m041ac16
+  (:set-compliance-slope ;; for one joint
+   (id slope)
+   "Set compliance slope for one joint. id should be 1-7. slope is 32 by default."
+   (ros::service-call
+    (format nil "/arm_j~d_controller/set_compliance_slope" id)
+    (instance dynamixel_controllers::setcomplianceslopeRequest :init
+              :slope (round slope)))
+   )
+  (:compliance-slope-vector
+   (av)
+   "Set compliance slope vector for all joints. #f(32 32 32 32 32 32 32) by default."
+   (dotimes (i (length av))
+     (send self :set-compliance-slope (1+ i) (elt av i)))
+   )
+  (:set-torque-limit
+   (id torque-limit)
+   "Set torque limit for one joint. id should be 1-7. torque-limit should be within [0, 1]."
+   (ros::service-call
+    (format nil "/arm_j~d_controller/set_torque_limit" id)
+    (instance dynamixel_controllers::SetTorqueLimitRequest :init
+              :torque_limit torque-limit)))
+  (:torque-enable
+   (id torque-enable)
+   "Configure joint torque mode for one joint. id sohuld be 1-7. If torque-enable is t, move to torque control mode, otherwise, move to joint positoin mode."
+   (ros::service-call
+    (format nil "/arm_j~d_controller/torque_enable" id)
+    (instance dynamixel_controllers::TorqueEnableRequest :init
+              :torque_enable torque-enable)))
+
+  ;; サーボON/OFFメソッド
+  (:servo-on
+   (id)
+   "Servo On for one joint. id should be 1-7."
+   (send self :servo-on-off id t))
+  (:servo-off
+   (id)
+   "Servo Off for one joint. id should be 1-7."
+   (send self :servo-on-off id nil))
+  (:servo-on-all
+   ()
+   "Servo On for all joints."
+   (dotimes (i (length (send robot :angle-vector)))
+     (send self :servo-on-off (1+ i) t)))
+  (:servo-off-all
+   ()
+   "Servo Off for all joints."
+   (dotimes (i (length (send robot :angle-vector)))
+     (send self :servo-on-off (1+ i) nil)))
+  (:servo-on-off
+   (id on/off) ;; id = 1-7, t -> "On", nil -> "Off"
+   (format t ";; servo ~A id = ~d~%" (if on/off "On" "Off") id)
+   (send self :torque-enable id on/off)
+   (if on/off ;; just for servo off->on
+       (send self :set-torque-limit id 1.0)))
+
+  ;; 把持モード開始メソッド
+  (:start-grasp
+   (&optional (arm :arm) &key ((:gain g) 0.5) ((:objects objs) objects))
+   "Start grasp mode."
+   (send self :set-compliance-slope 7 1023)
+   (send self :set-torque-limit 7 g)
+   (send robot :gripper arm :angle-vector
+         (send-all (send robot :gripper arm :joint-list) :min-angle))
+   (send self :angle-vector (send robot :angle-vector) 1000 :gripper-controller)
+   (send self :wait-interpolation :gripper-controller)
+   (send self :state)
+   (send robot :gripper arm :angle-vector
+         (mapcar #'(lambda (x) (- x 5)) (send-all (send robot :gripper arm :joint-list) :joint-angle))) ;; 5[deg]
+   (send self :angle-vector (send robot :angle-vector) 200 :gripper-controller)
+   (send self :wait-interpolation :gripper-controller)
+   )
+  ;; 把持モード停止メソッド
+  (:stop-grasp
+   (&optional (arm :arm) &key (wait nil))
+   "Stop grasp mode."
+   (send robot :gripper arm :angle-vector
+         (send-all (send robot :gripper arm :joint-list) :max-angle))
+   (send self :angle-vector (send robot :angle-vector) 1000 :gripper-controller)
+   (send self :set-compliance-slope 7 32)
+   (send self :set-torque-limit 7 1.0)
+   (send self :wait-interpolation :gripper-controller)
+   )
+  )
+)
+

--- a/dynamixel_3dof_arm/euslisp/dxl-3dof-arm-interface.l
+++ b/dynamixel_3dof_arm/euslisp/dxl-3dof-arm-interface.l
@@ -1,0 +1,47 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; 3dof アームロボットのrobot-interfaceクラス
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(require :robot-interface "package://pr2eus/robot-interface.l")
+(require :dxl-3dof-arm-robot "package://dynamixel_3dof_arm/euslisp/dxl-3dof-arm-robot.l")
+
+;; loadする台車・アームのrobot-interfaceクラスのメソッド定義ファイル
+(load "package://dynamixel_3dof_arm/euslisp/dxl-3dof-arm-interface-common.l")
+(ros::load-ros-manifest "control_msgs")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; 3dof アームロボットのrobot-interfaceクラス定義
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(defclass dxl-3dof-arm-interface
+  :super robot-interface
+  :slots ())
+
+(eval `(defmethod dxl-3dof-arm-interface
+         ;; dxl-3dof-arm-interfaceのメソッドをdefmethodする
+         ,@(get-method-list-for-dxl-3dof-arm-interface)
+         ))
+(defmethod dxl-3dof-arm-interface
+  (:init
+   (&rest args)
+   (prog1
+       (send-super :init :robot dxl-3dof-arm-robot)
+     (send self :initialize-arm-robot-ros)
+     )
+   )
+  )
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; アーム台車ロボット用初期化関数
+;;   robot-interface (*ri*) とモデル (*dxl-3dof-arm*)を生成する
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(defun dxl-3dof-arm-init ()
+  "Initialization function for *ri* and *dxl-3dof-arm*."
+  (if (not (boundp '*ri*)) ;; real robot interface
+      (setq *ri* (instance dxl-3dof-arm-interface :init)))
+  (if (not (boundp '*dxl-3dof-arm*)) ;; Euslisp model
+      (setq *dxl-3dof-arm* (instance dxl-3dof-arm-robot :init)))
+  (objects (list *dxl-3dof-arm*))
+  (send *irtviewer* :change-background #f(0.9 0.9 0.9))
+  (send *irtviewer* :draw-objects)
+  )
+(warn ";; (dxl-3dof-arm-init) ;; for initialize ~%")

--- a/dynamixel_3dof_arm/euslisp/dxl-3dof-arm-robot.l
+++ b/dynamixel_3dof_arm/euslisp/dxl-3dof-arm-robot.l
@@ -1,0 +1,531 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Dynamixel AX-12Aモータによる3DOF アームロボット
+;;   3dof = 6dof arm + 1dof gripper
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; body生成関数
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Dynamixel AX-12A
+;;   http://www.besttechnology.co.jp/modules/knowledge/?BTX030B%20Dynamixel%20AX-12A
+(defun make-dynamixel-AX-12A-motor-body ()
+  (let ((b1 (make-cube 26 11.5 32))
+        (b2 (make-cube 32 38.5 32))
+        (b3 (make-cylinder (/ 22 2.0) 5))
+        (b4 (make-cylinder (/ 10 2.0) 3))
+        )
+    (send b1 :translate (float-vector 0 (/ 11.5 2.0) 0))
+    (send b2 :translate (float-vector 0 (/ 38.5 -2.0) 0))
+    (send b3 :translate (float-vector 0 0 (/ 32 2.0)))
+    (send b4 :translate (float-vector 0 0 (- (+ (/ 32 2.0) 3))))
+    (let ((b (body+ b1 b2 b3 b4)))
+      (send b :set-color :gray10)
+      (send b :put :attach-coords (make-cascoords :pos (float-vector 0 -13.5 -16)))
+      (send b :assoc (send b :get :attach-coords))
+      (send b :put :joint-coords (make-cascoords :pos (float-vector 0 0 (+ 16 5))))
+      (send b :assoc (send b :get :joint-coords))
+      b)))
+
+;; Small frame parts for Dynamixel AX-12A
+;;  F3 in http://www.besttechnology.co.jp/modules/knowledge/?BTX030B%20Dynamixel%20AX-12A
+(defun make-dynamixel-AX-12A-frame1-body ()
+  (let ((b1 (make-cube 25 32 4))
+        (b2 (make-cube 25 3.1 9))
+        (b3 (make-cube 25 3.1 9)))
+    (send b1 :translate (float-vector 0 0 3.5))
+    (send b2 :translate (float-vector 0 17.55 1.0))
+    (send b3 :translate (float-vector 0 -17.55 1.0))
+    (let ((b (body+ b1 b2 b3)))
+      (send b :set-color :slategray)
+      (send b :put :attach-coords (make-cascoords :pos (float-vector 0 0 5.5)))
+      (send b :assoc (send b :get :attach-coords))
+      b)))
+
+;; Large frame parts for Dynamixel AX-12A
+;;  F2 in http://www.besttechnology.co.jp/modules/knowledge/?BTX030B%20Dynamixel%20AX-12A
+(defun make-dynamixel-AX-12A-frame2-body ()
+  (let ((b1 (make-cube 24.8 41.8 7))
+        (b2 (make-cube 24.8 3.2 37.5))
+        (b3 (make-cube 24.8 3.2 37.5)))
+    (send b1 :translate (float-vector 0 0 23))
+    (send b2 :translate (float-vector 0 22.5 7.75))
+    (send b3 :translate (float-vector 0 -22.5 7.75))
+    (let ((b (body+ b1 b2 b3)))
+      (send b :set-color :slategray)
+      (send b :put :attach-coords (make-cascoords :pos (float-vector 0 0 26.5) :rpy (list 0 pi 0)))
+      (send b :assoc (send b :get :attach-coords))
+      b)))
+
+;; gripper parts
+(defun make-dxl-3dof-arm-gripper-body ()
+  (let ((b1 (make-prism
+             (list (float-vector 0 80 0)
+                   (float-vector 5 80 0)
+                   (float-vector 15 35 0)
+                   (float-vector 15 0 0)
+                   (float-vector 0 0 0)
+                   )
+             40))
+        (b2 (make-cube 50 100 38)))
+    (send b2 :translate (float-vector (+ 25 1) (- 50 1) (+ 1 (/ 38 2.0))))
+    (let ((b (body- b1 b2)))
+      (send b :translate-vertices (float-vector 0 -13 -20))
+      (send b :set-color :silver)
+      b)))
+
+;; base parts
+(defun make-dxl-3dof-arm-base-body ()
+  (let ((b1 (make-cube 41 30 5))
+        (b2 (make-cube 5 30 40)))
+    (send b1 :translate (float-vector -7.5 0 2.5))
+    (send b2 :translate (float-vector -25.5 0 20))
+    (let ((b (body+ b1 b2)))
+      (send b :set-color :silver)
+      (send b :put :attach-coords (make-cascoords :pos (float-vector -28 0 21.5) :rpy (list 0 pi/2 0)))
+      (send b :assoc (send b :get :attach-coords))
+      b)))
+
+;; motor+frame1
+(defun make-dynamixel-AX-12A-motor-unit-bodyset
+  (&key (use-frame1 (list :bottom :left)))
+  (let* ((motor-body (make-dynamixel-AX-12A-motor-body))
+        (frame1-bodies
+         (mapcar #'(lambda (x)
+                     (let ((b (make-dynamixel-AX-12A-frame1-body)))
+                       (case x
+                         (:bottom
+                          (send b :name :bottom)
+                          (send b :rotate pi/2 :x)
+                          (send b :translate (float-vector 0 0 36)))
+                         (:left
+                          (send b :name :left)
+                          (send b :rotate pi/2 :x)
+                          (send b :rotate -pi/2 :y)
+                          (send b :translate (float-vector (/ 27 -2.0) -14.5 0) :world))
+                         (:right
+                          (send b :name :right)
+                          (send b :rotate pi/2 :x)
+                          (send b :rotate pi/2 :y)
+                          (send b :translate (float-vector (/ 27 2.0) -14.5 0) :world))
+                         (t ))
+                       (list x b)))
+                 use-frame1))
+        (unit-bodies
+         (append (list (list :motor motor-body))
+                 frame1-bodies)))
+    (send motor-body :name :motor)
+    (dolist (b (cdr unit-bodies))
+      (send (cadr (car unit-bodies)) :assoc (cadr b)))
+    (let ((b (instance bodyset :init (make-cascoords)
+                       :bodies (mapcar #'cadr unit-bodies))))
+      (send b :put :joint-coords (make-cascoords :coords (send (send (cadr (car unit-bodies)) :get :joint-coords) :copy-worldcoords)))
+      (send b :assoc (send b :get :joint-coords))
+      (dolist (bb unit-bodies)
+        (send b :put (read-from-string (format nil "~A-attach-coords" (car bb)))
+              (send (cadr bb) :get :attach-coords)))
+      b)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; リンク生成関数
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; root-link : base+frame1-bottom+motor
+(defun make-dxl-3dof-arm-root-link ()
+  (let ((b1s (make-dynamixel-AX-12A-motor-unit-bodyset :use-frame1 (list :bottom)))
+        (b2 (make-dxl-3dof-arm-base-body)))
+    (send b2 :move-coords
+          (send b1s :get :bottom-attach-coords) (send b2 :copy-worldcoords))
+    (send b1s :rotate -pi/2 :y)
+    (let ((bs (append (send b1s :bodies) (list b2))))
+      (dolist (b (cdr bs)) (send (car bs) :assoc b))
+      (send (car bs) :rotate pi/2 :y)
+      (send (car bs) :rotate pi/2 :z)
+      (send (car bs) :rotate pi :x)
+      (send (car bs) :translate
+            (v- (send (car bs) :worldpos) (send (send b2 :get :attach-coords) :worldpos))
+            :world)
+      (let ((bl (instance bodyset-link :init (make-cascoords)
+                          :bodies bs :name :root-link)))
+        (send bl :put :joint-coords
+              (make-cascoords :coords (send (send (send (car bs) :copy-worldcoords) :rotate pi :y) :rotate pi/2 :z)))
+        (send bl :assoc (send bl :get :joint-coords))
+        bl))))
+
+;; link1 : frame2
+(defun make-dxl-3dof-arm-link1 ()
+  (let ((b (make-dynamixel-AX-12A-frame2-body)))
+    (send b :rotate -pi/2 :x)
+    (send b :rotate -pi/2 :z :world)
+    (let ((bl (instance bodyset-link :init (make-cascoords)
+                        :bodies (list b) :name :arm-link1)))
+      (send bl :put :joint-coords
+            (make-cascoords :coords (send (send (send (send b :get :attach-coords) :copy-worldcoords) :rotate pi/2 :y) :rotate pi/2 :x :world)))
+      (send bl :assoc (send bl :get :joint-coords))
+      bl)))
+
+;; link2 : motor+frame1bottom+frame1left+motor
+(defun make-dxl-3dof-arm-link2 ()
+  (let ((b1s (make-dynamixel-AX-12A-motor-unit-bodyset :use-frame1 (list :bottom)))
+        (b2s (make-dynamixel-AX-12A-motor-unit-bodyset :use-frame1 (list :left))))
+    (send b2s :move-coords
+          (send (send (send (send b1s :get :bottom-attach-coords) :copy-worldcoords) :rotate pi :x) :rotate -pi/2 :z)
+          (send b2s :get :left-attach-coords))
+    (let ((bs (append (send b1s :bodies) (send b2s :bodies))))
+      (dolist (b (cdr bs)) (send (car bs) :assoc b))
+      (send (car bs) :rotate -pi/2 :y)
+      (send (car bs) :rotate -pi/2 :x :world)
+      (send (car bs) :translate (v- (send (car bs) :worldpos) (send (send (car bs) :get :joint-coords) :worldpos)) :world)
+      (let ((bl (instance bodyset-link :init (make-cascoords)
+                          :bodies bs :name :arm-link2)))
+        (send bl :put :joint-coords
+              (make-cascoords :coords (send (send (send (send (elt bs 2) :copy-worldcoords) :rotate -pi/2 :x) :rotate -pi/2 :y :world) :rotate pi :z :world)))
+        (send bl :assoc (send bl :get :joint-coords))
+        bl))))
+
+;; link3 : frame2-0+offset+motor
+(defun make-dxl-3dof-arm-link3 ()
+  (let ((b1 (make-dynamixel-AX-12A-motor-body))
+        (b2 (make-dynamixel-AX-12A-frame2-body)))
+    (send b2 :move-coords
+          (send b1 :get :attach-coords)
+          (send (send (send (send b2 :get :attach-coords) :rotate pi :x) :rotate pi/2 :z)
+                :translate (float-vector 0 0 8)))
+    (let ((bs (list b1 b2)))
+      (dolist (b (cdr bs)) (send (car bs) :assoc b))
+      (send (car bs) :rotate pi/2 :y)
+      (send (car bs) :rotate pi/2 :x :world)
+      (send b1 :translate (v- (send b1 :worldpos) (send b2 :worldpos)) :world)
+      (let ((bl (instance bodyset-link :init (make-cascoords)
+                          :bodies bs :name :arm-link3)))
+        (send bl :put :joint-coords
+              (make-cascoords
+               :coords
+               (send (send (send (send (car bs) :get :joint-coords) :copy-worldcoords) :rotate -pi/2 :x) :rotate -pi/2 :z)))
+        (send bl :assoc (send bl :get :joint-coords))
+        bl))))
+
+;; link4 : frame2
+(defun make-dxl-3dof-arm-link4 ()
+  (let ((b (make-dynamixel-AX-12A-frame2-body)))
+    (send b :rotate -pi/2 :y)
+    (send b :translate (v- (send b :worldpos) (send (send b :get :attach-coords) :worldpos)) :world)
+    (let ((bl (instance bodyset-link :init (make-cascoords)
+                        :bodies (list b) :name :arm-link4)))
+      (send bl :put :joint-coords
+            (make-cascoords :coords (send (send b :copy-worldcoords) :rotate pi/2 :y)))
+      (send bl :assoc (send bl :get :joint-coords))
+      bl)))
+
+;; link5 : motor+frame1-bottom
+(defun make-dxl-3dof-arm-link5 ()
+  (let ((b1s (make-dynamixel-AX-12A-motor-unit-bodyset :use-frame1 (list :bottom))))
+    (let ((bs (send b1s :bodies)))
+      (dolist (b (cdr bs)) (send (car bs) :assoc b))
+      (send (car bs) :rotate -pi/2 :x)
+      (send (car bs) :rotate pi/2 :y :world)
+      (let ((bl (instance bodyset-link :init (make-cascoords)
+                          :bodies bs :name :arm-link5)))
+        (send bl :put :joint-coords
+              (make-cascoords :coords (send (send (send b1s :get :bottom-attach-coords) :copy-worldcoords) :rotate -pi/2 :y)))
+        (send bl :assoc (send bl :get :joint-coords))
+        bl))))
+
+;; link6 : motor+offset+frame1-left+motor+frame1-bottom+gripper
+(defun make-dxl-3dof-arm-link6 ()
+  (let ((b1 (make-dynamixel-AX-12A-motor-body))
+        (b2s (make-dynamixel-AX-12A-motor-unit-bodyset :use-frame1 (list :left :bottom)))
+        (b3 (make-dxl-3dof-arm-gripper-body)))
+    (send b2s :move-coords
+          (send b1 :get :attach-coords)
+          (send (send (send b2s :get :left-attach-coords) :copy-worldcoords) :translate (float-vector 0 0 7)))
+    (send b3 :move-coords
+          (send (send (send b2s :get :bottom-attach-coords) :rotate -pi/2 :y :world) :rotate -pi/2 :x :world)
+          (send b3 :copy-worldcoords))
+    (let ((bs (append (list b1) (send b2s :bodies) (list b3))))
+      (dolist (b (cdr bs)) (send (car bs) :assoc b))
+      (send (car bs) :rotate -pi/2 :y)
+      (send (car bs) :rotate pi/2 :x :world)
+      (send (car bs) :translate (v- (send b1 :worldpos) (send (send b1 :get :joint-coords) :worldpos))
+            :world)
+      (let ((bl (instance bodyset-link :init (make-cascoords)
+                          :bodies bs :name :arm-link6)))
+        (send bl :put :joint-coords
+              (make-cascoords :coords (send (send (elt bs 1) :copy-worldcoords) :rotate 0 :x)))
+        (send bl :assoc (send bl :get :joint-coords))
+        bl))))
+
+;; link7 : frame2+gripper
+(defun make-dxl-3dof-arm-link7 ()
+  (let ((b1 (make-dynamixel-AX-12A-frame2-body))
+        (b2 (make-dxl-3dof-arm-gripper-body)))
+    (send b2 :move-coords
+          (send b1 :get :attach-coords)
+          (send (send (send b2 :copy-worldcoords) :rotate -pi/2 :y) :rotate pi/2 :z))
+    (let ((bs (list b1 b2)))
+      (dolist (b (cdr bs)) (send (car bs) :assoc b))
+      (send (car bs) :rotate pi :z)
+      (send (car bs) :rotate -pi/2 :x :world)
+      (instance bodyset-link :init (make-cascoords)
+                :bodies bs :name :arm-link7)
+      )))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; 3DOF アームロボットモデルクラス
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defclass dxl-3dof-arm-robot
+  :super robot-model
+  :slots (jc0 jc1 jc2 jc3 jc4 jc5 jc6)) ;; 関節インスタンス
+
+(defmethod dxl-3dof-arm-robot
+  (:init
+   (&rest args
+    &key (name "dxl-3dof-arm-robot"))
+   (send-super* :init :name name args)
+   ;; 1. make links links and assoc all links
+   (let ((aroot-link (send self :make-root-link)))
+     (setq rarm (send self :make-arm-links))
+     (send (car rarm) :move-coords (send aroot-link :get :joint-coords) (send (car rarm) :copy-worldcoords))
+     ;; 2. assoc links
+     ;;    Root link should be associated with "self".
+     (send self :assoc aroot-link)
+     (send aroot-link :assoc (car rarm))
+
+     ;; 3. make all joints
+     ;;    Before making joints, you should :assoc all links.
+     (let (
+           ;; http://www.besttechnology.co.jp/modules/knowledge/?BTX030B%20Dynamixel%20AX-12A
+           (max-joint-velocity (/ (* 59 2pi) 60.0)) ;; [rad/s]
+           (max-joint-torque 12.0)) ;; [Nm]
+       (setq jc0 (instance rotational-joint :init :parent-link aroot-link :child-link (elt rarm 0) :name "arm_joint1" :axis :-z :min -150 :max 150 :max-joint-velocity max-joint-velocity :max-joint-torque max-joint-torque))
+       (setq jc1 (instance rotational-joint :init :parent-link (elt rarm 0) :child-link (elt rarm 1) :name "arm_joint2" :axis :x :min -150 :max 150 :max-joint-velocity max-joint-velocity :max-joint-torque max-joint-torque))
+       (setq jc2 (instance rotational-joint :init :parent-link (elt rarm 1) :child-link (elt rarm 2) :name "arm_joint3" :axis :y :min -150 :max 150 :max-joint-velocity max-joint-velocity :max-joint-torque max-joint-torque))
+       ;; (setq jc3 (instance rotational-joint :init :parent-link (elt rarm 2) :child-link (elt rarm 3) :name "arm_joint4" :axis :x :min -180 :max 180 :max-joint-velocity max-joint-velocity :max-joint-torque max-joint-torque))
+       ;; (setq jc4 (instance rotational-joint :init :parent-link (elt rarm 3) :child-link (elt rarm 4) :name "arm_joint5" :axis :y :min -90 :max 90 :max-joint-velocity max-joint-velocity :max-joint-torque max-joint-torque))
+       ;; (setq jc5 (instance rotational-joint :init :parent-link (elt rarm 4) :child-link (elt rarm 5) :name "arm_joint6" :axis :x :min -180 :max 180 :max-joint-velocity max-joint-velocity :max-joint-torque max-joint-torque))
+       ;; (setq jc6 (instance rotational-joint :init :parent-link (elt rarm 5) :child-link (elt rarm 6) :name "arm_joint7" :axis :z :min -55 :max 50 :max-joint-velocity max-joint-velocity :max-joint-torque max-joint-torque))
+       )
+
+     ;; 4. define slots for robot class
+     ;;    links and joint-list for cascaded-link.
+     (setq links (append (list aroot-link) rarm))
+     (setq joint-list (list jc0 jc1 jc2));; jc3 jc4 jc5 jc6))
+     ;;    These are for robot-model.
+     (setq rarm-root-link (car rarm))
+     ;;    end-coords
+     (setq rarm-end-coords (make-cascoords :coords
+                                           (send (send (car (last rarm)) :copy-worldcoords) :translate (float-vector 100 0 0))))
+     (send (car (last rarm)) :assoc rarm-end-coords)
+
+     ;; 5. call :init-ending after defining links and joint-list and return "self"
+     (send self :init-ending)
+     self))
+  ;; links
+  (:make-root-link
+   ()
+   (make-dxl-3dof-arm-root-link))
+  (:make-arm-links
+   ()
+   (let ((ln
+          (list (make-dxl-3dof-arm-link1)
+                (make-dxl-3dof-arm-link2)
+                (make-dxl-3dof-arm-link3)
+;                (make-dxl-3dof-arm-link4)
+;                (make-dxl-3dof-arm-link5)
+;                (make-dxl-3dof-arm-link6)
+;                (make-dxl-3dof-arm-link7)
+                 )))
+     (dotimes (i (1- (length ln)))
+       (send (elt ln (1+ i)) :move-coords
+             (send (elt ln i) :get :joint-coords)
+             (send (elt ln (1+ i)) :copy-worldcoords)))
+     (dotimes (i (1- (length ln)))
+       (send (elt ln i) :assoc (elt ln (1+ i))))
+     ln))
+  ;; joints
+  (:arm_joint1 () jc0)
+  (:arm_joint2 () jc1)
+  (:arm_joint3 () jc2)
+  (:arm_joint4 () jc3)
+  (:arm_joint5 () jc4)
+  (:arm_joint6 () jc5)
+  (:arm_joint7 () jc6)
+  ;; limbs
+  (:arm (&rest args)
+        "Accessor for arm methods."
+        (unless args (setq args (list nil))) (send* self :limb :rarm args))
+  ;; poses
+  (:reset-pose
+   ()
+   "Reset pose."
+   (send self :angle-vector (float-vector 0.0 0.0 0));
+;   (send self :angle-vector (float-vector 0.0 0.0 -90.0 0.0 90.0 0.0 0.0)))
+  ;; (:reset-pose2
+  ;;  ()
+  ;;  "Reset pose2."
+  ;;  (send self :angle-vector (float-vector 0.0 150.0 -90.0 0.0 90.0 0.0 0.0)))
+  ;; (:tuckarm-pose
+  ;;  ()
+  ;;  "Folding arm pose."
+  ;;  (send self :angle-vector (float-vector 0.0 150.0 -90.0 0.0 0.0 0.0 0.0)))
+  ;; (:tuckarm-pose2
+  ;;  ()
+  ;;  "Folding arm pose2."
+  ;;  (send self :angle-vector (float-vector 90.0 90.0 5.0 0.0 -90.0 90.0 0.0)))
+  ;; (:tuckarm-pose3
+  ;;  ()
+  ;;  "Folding arm pose3."
+  ;;  (send self :angle-vector (float-vector 0.0 90.0 0.0 -20.0 90.0 0.0 0.0)))
+  ;; inverse-kinematics
+  (:inverse-kinematics
+   (target-coords &rest args &key (link-list)
+                  (move-target) (stop 300)
+                  (use-base nil) (start-coords (send self :copy-worldcoords))
+                  (thre (cond
+                         ((atom target-coords) 10)
+                         (t (make-list (length target-coords) :initial-element 10))))
+                  (rthre (cond
+                         ((atom target-coords) (deg2rad 5))
+                         (t (make-list (length target-coords) :initial-element (deg2rad 5)))))
+                  (base-range (list :min #f(-30 -30) :max #f( 30  30)))
+                  &allow-other-keys)
+   "Inverse kinemaitcs method for arm robot."
+   (let (diff-pos-rot)
+     (unless move-target
+       (setq move-target (send self :arm :end-coords)))
+     (unless link-list
+       (setq link-list (send self :link-list (send move-target :parent))))
+
+     ;; use base
+     (cond
+      (use-base
+       (setq diff-pos-rot
+             (concatenate float-vector
+                          (send start-coords :difference-position self)
+                          (send start-coords :difference-rotation self)))
+       (send self :move-to start-coords :world)
+       (with-append-root-joint
+        (ll self link-list
+            :joint-class wheel-joint
+            :joint-args base-range)
+        (send (caar ll) :joint :joint-angle
+              (float-vector (elt diff-pos-rot 0)
+                            (rad2deg (elt diff-pos-rot 5))))
+        (send-super* :inverse-kinematics target-coords
+                     :rthre rthre
+                     :thre thre
+                     :stop stop
+                     :additional-weight-list
+                     (list
+                      (list (car (send self :links))
+                            (if (eq use-base t) 1 use-base))
+                      )
+                     :link-list (car ll) ;; link-list
+                     :move-target move-target
+                    args)))
+      (t
+       (send-super* :inverse-kinematics target-coords
+                    :rthre rthre
+                    :thre thre
+                    :stop stop
+                    :link-list link-list
+                    :move-target move-target
+                    args))
+       )))
+  )
+
+;; 3dofアームモデル生成関数
+(defun dxl-3dof-arm
+  ()
+  "Generation function for dxl-3dof-arm-robot."
+  (instance dxl-3dof-arm-robot :init))
+
+#|
+(defun init-model-viewer ()
+  (setq *dxl-3dof-arm* (dxl-3dof-arm))
+  (objects (list *dxl-3dof-arm*))
+  (send *irtviewer* :change-background #f(0.9 0.9 0.9))
+  t)
+
+(defun test-arm-fk (&key (div 50))
+  (dolist (j (send *dxl-3dof-arm* :joint-list))
+    (send *dxl-3dof-arm* :init-pose)
+    (dotimes (i (1+ div))
+      (let ((dja (/ (- (send j :max-angle) (send j :min-angle)) (float div))))
+        (send j :joint-angle (+ (send j :min-angle) (* i dja)))
+        (send *irtviewer* :draw-objects)
+        (unix:usleep 5000)
+        )))
+  )
+
+(defun ik-demo0
+  (&key (step 10)        ;;stepは一回のループで目標を動かす距離
+        (use-wheel nil)  ;;車輪を使ってIKを解くかどうか
+        )
+  ;;逆運動学が解きやすい初期姿勢に変更
+  (send *dxl-3dof-arm* :reset-pose)
+  (send *irtviewer* :draw-objects)
+  (when (boundp '*ri*)
+    (send *ri* :angle-vector (send *dxl-3dof-arm* :angle-vector) 5000)
+    (send *ri* :wait-interpolation))
+  ;;
+  ;;'e'を押すまで続ける
+  (warning-message 2 ";; if stop, then enter e~%")
+  (warning-message 2 ";;  h:left, j:down, k:up, l:right, f:forward, b:back~%")
+  (let (w goal-endcoords ll)
+    ;;もし腕しか使わない場合はlinklistをあらかじめ用意しておく
+    (when (not use-wheel)
+      (setq ll 
+            (send *dxl-3dof-arm* :link-list
+                  (send *dxl-3dof-arm* :arm :end-coords :parent) ;;ここまで
+                  )))
+    ;;目標座標を作成する(デフォルトは、台車の手先位置と同じにする)
+    (setq goal-endcoords
+          (make-cascoords :pos (send *dxl-3dof-arm* :arm :end-coords :worldpos)))
+    ;;ループを回す
+    (while t
+      (setq w (read-line)) ;;文字を取得
+      ;;文字によって操作を変える
+      (cond
+       ((equal w "e")
+        (return-from nil)) ;;loopから抜けて終了
+       ((equal w "h")  ;;左へ動かす
+        (send goal-endcoords :locate (float-vector 0 step 0)))
+       ((equal w "j")  ;;下へ動かす
+        (send goal-endcoords :locate (float-vector 0 0 (* -1 step))))
+       ((equal w "k")  ;;上へ動かす
+        (send goal-endcoords :locate (float-vector 0 0 step)))
+       ((equal w "l")  ;;右へ動かす
+        (send goal-endcoords :locate (float-vector 0 (* -1 step) 0)))
+       ((equal w "f")  ;;前へ動かす
+        (send goal-endcoords :locate (float-vector step 0 0)))
+       ((equal w "b")  ;;後へ動かす
+        (send goal-endcoords :locate (float-vector (* -1 step) 0 0)))
+       ((not w)) ;;何も入れられなければ何もしない
+       (t
+        (warning-message 2 ";; no such command~%")
+        (warning-message 2 ";; if stop, then enter e~%")
+        (warning-message 2 ";;  h:left, j:down, k:up, l:right, f:forward, b:back~%")
+        ))
+      ;;目標値end-coordsに向かって逆運動学を解いて、動かす
+      ;;  solve-ikという逆運動学をとくmethodを呼び出す。
+      (cond
+       (use-wheel ;;車輪を使う場合
+        (send *dxl-3dof-arm* :inverse-kinematics goal-endcoords :rotation-axis nil :debug-view nil))
+       (t
+        (send *dxl-3dof-arm* :inverse-kinematics goal-endcoords :rotation-axis nil :debug-view nil :link-list ll :move-target (send *dxl-3dof-arm* :arm :end-coords)))
+       )
+      (send *irtviewer* :objects (list *dxl-3dof-arm* goal-endcoords))
+      (send *irtviewer* :draw-objects)
+      (when (boundp '*ri*)
+        (send *ri* :angle-vector (send *dxl-3dof-arm* :angle-vector) 500)
+        (send *ri* :wait-interpolation))
+      ))
+  (warn ";; finished~%")
+  )
+
+;; old version functions
+
+;; version 1
+|#

--- a/dynamixel_3dof_arm/euslisp/dxl-3dof-armed-turtlebot-interface.l
+++ b/dynamixel_3dof_arm/euslisp/dxl-3dof-armed-turtlebot-interface.l
@@ -1,0 +1,51 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; アーム台車ロボットのrobot-interfaceクラス
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(load "package://dynamixel_3dof_arm/euslisp/dxl-armed-turtlebot.l")
+(require :robot-interface "package://pr2eus/robot-interface.l")
+
+;; loadする台車・アームのrobot-interfaceクラスのメソッド定義ファイル
+(load "package://turtleboteus/euslisp/turtlebot-interface-common.l")
+(load "package://dynamixel_3dof_arm/euslisp/dxl-3dof-arm-interface-common.l")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; アーム台車ロボットのrobot-interfaceクラス定義
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(defclass dxl-armed-turtlebot-interface
+  :super robot-interface
+  :slots ())
+
+(eval `(defmethod dxl-armed-turtlebot-interface
+         ;; dxl-7dof-arm-interface, turtlebot-interfaceのメソッドをそれぞれdefmethodする
+         ,@(get-method-list-for-dxl-3dof-arm-interface)
+         ,@(get-method-list-for-turtlebot-interface)
+         ))
+(defmethod dxl-armed-turtlebot-interface
+  (:init
+   (&rest args)
+   (prog1
+       (send-super* :init :robot dxl-armed-turtlebot-robot args)
+     ;; それぞれのcallback登録など
+     (send self :initialize-turtlebot-ros)
+     (send self :initialize-arm-robot-ros)
+     )
+   )
+  )
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; アーム台車ロボット用初期化関数
+;;   robot-interface (*ri*) とモデル (*dxl-armed-turtlebot*)を生成する
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(defun dxl-armed-turtlebot-init
+  (&key (objects))
+  "Initialization function for *ri* and *dxl-armed-turtlebot*."
+  (if (not (boundp '*ri*))
+      (setq *ri* (instance dxl-armed-turtlebot-interface :init :objects objects)))
+  (if (not (boundp '*dxl-armed-turtlebot*))
+      (setq *dxl-armed-turtlebot* (dxl-armed-turtlebot)))
+  (objects (list *dxl-armed-turtlebot*))
+  (send *irtviewer* :change-background #f(0.9 0.9 0.9))
+  (send *irtviewer* :draw-objects)
+  )
+(warn ";; (dxl-armed-turtlebot-init) ;; for initialize ~%")

--- a/dynamixel_3dof_arm/euslisp/dxl-armed-turtlebot.l
+++ b/dynamixel_3dof_arm/euslisp/dxl-armed-turtlebot.l
@@ -1,0 +1,114 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; turtlebotとdynamixel-3dof-armを組み合わせたアーム台車ロボット
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; loadする台車・アームのモデルファイル
+(require :turtlebot-with-sensors-robot "package://turtleboteus/euslisp/turtlebot-with-sensors-robot.l")
+(require :dxl-3dof-arm-robot "package://dynamixel_3dof_arm/euslisp/dxl-3dof-arm-robot.l")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; アーム台車ロボットモデルクラス
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;   turtlebotは継承、dynamixel-3dof-armはスロット変数として確保
+(defclass dxl-armed-turtlebot-robot
+  :super turtlebot-with-sensors-robot
+  :slots (arm-robot
+          arm-base-fixed-joint ;; アームのルートリンクと台車を接続するための関節
+          )
+  )
+
+(defmethod dxl-armed-turtlebot-robot
+  (:init
+   (&rest args
+    &key (name "dxl-armed-turtlebot-robot")
+         (arm-origin-coords
+          ;; upper arm version
+          ;; (make-coords :pos (float-vector 85.725 9.525 410) ;; 9.525 = (/ 38.1 4.0), 38.1 = 2 pitch width, 85.725 = (+ (/ 152.4 2.0) (/ 38.1 4.0))
+          ;;              :rpy (list 0 0 0))
+          ;; lower arm version
+          ;; (make-coords :pos (float-vector 85.725 9.525 402) ;; 9.525 = (/ 38.1 4.0), 38.1 = 2 pitch width, 85.725 = (+ (/ 152.4 2.0) (/ 38.1 4.0))
+          ;;              :rpy (list 0 0 pi))
+          ;; upper arm version + 長いアーム台座
+          ;;(make-coords :pos (float-vector (+ 58.0 85.725) 9.525 402) ;; 9.525 = (/ 38.1 4.0), 38.1 = 2 pitch width, 85.725 = (+ (/ 152.4 2.0) (/ 38.1 4.0))
+          ;;             :rpy (list 0 0 0))
+          ;; lower arm version + 長いアーム台座
+          (make-coords :pos (float-vector (+ 58.0 85.725) 9.525 402) ;; 9.525 = (/ 38.1 4.0), 38.1 = 2 pitch width, 85.725 = (+ (/ 152.4 2.0) (/ 38.1 4.0))
+                       :rpy (list 0 0 pi))
+          )
+         ;; turtlebot CAD information is here:
+         ;;   http://files.yujinrobot.com/kobuki/hardware/drawings/pdf
+         ;; top plate cad:
+         ;;   http://files.yujinrobot.com/kobuki/hardware/drawings/pdf/plate_top.pdf
+         )
+   (prog1
+       (send-super* :init :name name args)
+     ;; アームモデルの生成
+     (setq arm-robot (instance dxl-3dof-arm-robot :init))
+     (send arm-robot :newcoords arm-origin-coords)
+     (send (car (send self :links)) :assoc (car (send arm-robot :links)))
+     (setq arm-base-fixed-joint
+           (instance rotational-joint
+                     :init :min 0 :max 0
+                     :name :arm-base-fixed-joint
+                     :child-link (car (send arm-robot  :links))
+                     :parent-link (car (send self :links))))
+     (setq links (append (send self :links) (cdr (send arm-robot :links)))
+           joint-list (send arm-robot :joint-list))
+     (let ((bk-bodies (append bodies (send arm-robot :bodies))))
+       (send self :init-ending)
+       (setq bodies bk-bodies))
+     (setq rarm-end-coords (arm-robot . rarm-end-coords))
+     (setq rarm-root-link (car (arm-robot . rarm)))
+     ;; xx-pose method copying
+     (send self :method-copying "-pose")
+     (send self :method-copying "_joint")
+     (send self :method-copying "inverse-kinematics" t)
+     t))
+  (:method-copying
+   (substr &optional (use-args nil))
+   (let ((methods
+          (remove-duplicates
+           (remove-if-not
+            #'(lambda (x) (substringp substr (string-downcase x)))
+            (send arm-robot :methods)))))
+     (dolist (me methods)
+       (eval
+        `(defmethod ,(send (class self) :name)
+           (,me
+            ,(if use-args '(&rest args) '())
+            ,(if use-args `(send* arm-robot ,me args) `(send arm-robot ,me))
+            )
+           ))
+       )))
+  ;; limbs
+  (:arm (&rest args)
+        (unless args (setq args (list nil))) (send* self :limb :rarm args))
+  )
+
+;; アーム台車モデル生成関数
+(defun dxl-armed-turtlebot
+  ()
+  "Generation function for dxl-armed-turtlebot-robot."
+  (instance dxl-armed-turtlebot-robot :init))
+
+#|
+(defun test ()
+  (setq *dxl-armed-turtlebot* (dxl-armed-turtlebot))
+  (objects (list *dxl-armed-turtlebot*))
+  (send *dxl-armed-turtlebot* :reset-pose)
+  (send *dxl-armed-turtlebot* :inverse-kinematics
+        (send (send (send *dxl-armed-turtlebot* :arm :end-coords) :copy-worldcoords) :translate (float-vector -100 0 -100) :world)
+        :link-list (send *dxl-armed-turtlebot* :link-list (send *dxl-armed-turtlebot* :arm :end-coords :parent))
+        :move-target (send *dxl-armed-turtlebot* :arm :end-coords)
+        :revert-if-fail nil
+        :rotation-axis nil :debug-view t)
+  (read-line)
+  (send *dxl-armed-turtlebot* :reset-pose2)
+  (send *dxl-armed-turtlebot* :inverse-kinematics
+        (send (send (send *dxl-armed-turtlebot* :arm :end-coords) :copy-worldcoords) :translate (float-vector 0 0 300) :world)
+        :link-list (send *dxl-armed-turtlebot* :link-list (send *dxl-armed-turtlebot* :arm :end-coords :parent))
+        :move-target (send *dxl-armed-turtlebot* :arm :end-coords)
+        :revert-if-fail nil
+        :rotation-axis nil :debug-view t)
+  )
+|#

--- a/dynamixel_3dof_arm/euslisp/thermo-speaker.l
+++ b/dynamixel_3dof_arm/euslisp/thermo-speaker.l
@@ -1,0 +1,41 @@
+(ros::load-ros-manifest "dynamixel_msgs")
+
+(ros::roseus "thermo_speaker")
+;;(load "package://pr2eus/speak.l")
+(ros::set-param "thermo_thre" 50)
+
+(defvar *arm-dof* 7)
+(setq *state-list* (make-list *arm-dof*))
+
+(defun state-cb
+  (msg)
+  (setf (elt *state-list* (1- (read-from-string (string-left-trim "arm_joint" (send msg :name))))) msg))
+
+(dotimes (i *arm-dof*)
+  (ros::subscribe (format nil "/arm_j~d_controller/state" (1+ i))
+                  dynamixel_msgs::JointState
+                  #'state-cb))
+
+(defun main () ;; [deg]
+  (ros::rate 0.1)
+  (do-until-key
+   (ros::spin-once)
+   (let ((thre (ros::get-param "thermo_thre")))
+     (if (and thre (every #'identity *state-list*))
+         (let ((mot
+                (remove-if-not
+                 #'(lambda (x)
+                     (> (elt (send x :motor_temps) 0) thre))
+                 *state-list*)))
+           (when mot
+             ;;(speak-jp "モータが/あ'つ'いです。")
+             (warn ";; motor ~A are hot (temp ~A > ~A)~%"
+                   (mapcar #'(lambda (x) (elt x 0)) (send-all mot :motor_temps))
+                   (mapcar #'(lambda (x) (elt x 0)) (send-all mot :motor_ids))
+                   thre)
+             )))
+     (ros::sleep)
+     )
+   ))
+
+(main)

--- a/dynamixel_3dof_arm/launch/dxl_3dof_armed_turtlebot_bringup.launch
+++ b/dynamixel_3dof_arm/launch/dxl_3dof_armed_turtlebot_bringup.launch
@@ -1,0 +1,34 @@
+<!-- -*- mode: XML -*- -->
+
+<launch>
+  <!-- 引数 -->
+  <!--   RVIZ を起動するか -->
+  <arg name="RUN_RVIZ" default="false"/>
+  <!--   rqt_reconfigure を起動するか -->
+  <arg name="RUN_RECONFIGURE_GUI" default="false"/>
+  <!--   ps3_teleop を起動するか -->
+  <arg name="RUN_PS3JOY" default="false"/>
+
+  <!-- 本体 -->
+  <!--   turtlebot関係 -->
+  <include file="$(find turtlebot_bringup)/launch/minimal.launch"/>
+<!-- いまはつかわない k-okada
+  <include file="$(find turtlebot_bringup)/launch/3dsensor.launch">
+    <arg name="3d_sensor" default="kinect" />
+  </include>
+-->
+  <include file="$(find dxl_armed_turtlebot)/launch/turtlebot_joystick_teleop.launch"
+           if="$(arg RUN_PS3JOY)"/>
+  <!-- <include file="$(find turtlebot_rviz_launchers)/launch/view_robot.launch"/> -->
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find turtlebot_rviz_launchers)/rviz/robot.rviz" respawn="true"
+        if="$(arg RUN_RVIZ)"/>
+  <!--   アームの起動 -->
+  <include file="$(find dynamixel_3dof_arm)/launch/dynamixel_3dof_arm_bringup.launch"/>
+  <!--   温度の表示プログラム -->
+  <node name="thermo_speaker" pkg="roseus"
+        type="roseus" args="$(find dynamixel_7dof_arm)/euslisp/thermo-speaker"
+        output="screen" respawn="true"/>
+  <!--   その他 -->
+  <node name="rqt_reconfigure" pkg="rqt_reconfigure" type="rqt_reconfigure"
+        if="$(arg RUN_RECONFIGURE_GUI)" respawn="true"/>
+</launch>

--- a/dynamixel_3dof_arm/launch/dynamixel_3dof_arm_bringup.launch
+++ b/dynamixel_3dof_arm/launch/dynamixel_3dof_arm_bringup.launch
@@ -1,0 +1,43 @@
+<!-- -*- mode: XML -*- -->
+
+<launch>
+    <node name="dynamixel_manager" pkg="dynamixel_controllers" type="controller_manager.py" required="true" output="screen">
+        <rosparam>
+            namespace: dxl_manager
+            serial_ports:
+                3dof_arm_port:
+                    port_name: "/dev/dynamixel_arm"
+                    baud_rate: 1000000
+                    min_motor_id: 1
+                    max_motor_id: 25
+                    update_rate: 20
+        </rosparam>
+    </node>
+
+    <!-- Load controller configuration to parameter server -->
+    <rosparam file="$(find dynamixel_3dof_arm)/config/dynamixel_joint_controllers.yaml" command="load"/>
+
+    <!-- start specified joint controllers -->
+    <node name="dynamixel_controller_spawner" pkg="dynamixel_controllers" type="controller_spawner.py"
+          args="--manager=dxl_manager
+                --port=3dof_arm_port
+                --type=simple
+                arm_j1_controller
+                arm_j2_controller
+                arm_j3_controller
+		"
+          output="screen"/>
+
+    <!-- start trajectory controllers for fullbody + gripper -->
+    <node name="dynamixel_trajectory_controller_spawner_for_fullbody" pkg="dynamixel_controllers" type="controller_spawner.py"
+          args="--manager=dxl_manager
+                --port=3dof_arm_port
+                --type=meta
+                fullbody_controller
+                arm_j1_controller
+                arm_j2_controller
+                arm_j3_controller
+"
+          output="screen"/>
+
+</launch>

--- a/dynamixel_3dof_arm/launch/soundplay.launch
+++ b/dynamixel_3dof_arm/launch/soundplay.launch
@@ -1,0 +1,7 @@
+<launch>
+  <node name="soundplay_node"    pkg="sound_play" type="soundplay_node.py"/>
+  <include file="$(find roseus_tutorials)/launch/aques-talk.launch"/>
+  <node name="play_initial_voice" pkg="roseus"
+	type="roseus" args="$(find pr2eus)/speak.l &quot;(progn (ros::roseus \&quot;play_initial_voice\&quot;) (while (/= 0 (unix:system \&quot;rosnode list | grep soundplay_node_jp\&quot;)) (unix:sleep 2)) (unix:sleep 4) (speak-jp \&quot;サウンドデバ&apos;イス,設定確認しま&apos;した．\&quot;) (exit))&quot;"
+	output="screen"/>
+</launch>

--- a/dynamixel_3dof_arm/package.xml
+++ b/dynamixel_3dof_arm/package.xml
@@ -1,0 +1,16 @@
+<package>
+  <name>dynamixel_3dof_arm</name>
+  <version>3.2.1</version>
+  <description>7dof dynamixel motor arm</description>
+  <license>BSD</license>
+  <maintainer email="nozawa@jsk.imi.i.u-tokyo.ac.jp">Shunichi Nozawa</maintainer>
+  <author email="nozawa@jsk.imi.i.u-tokyo.ac.jp">Shunichi Nozawa</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>dynamixel_controllers</build_depend>
+  <build_depend>pr2eus</build_depend>
+
+  <run_depend>dynamixel_controllers</run_depend>
+  <run_depend>pr2eus</run_depend>
+</package>


### PR DESCRIPTION
:go-pos, :go-velocity を使うために、turtlebot-interface-common.lを使いながら、dxl-3dof-arm-interface-common を使えるようにした例です。
ロボットのアームの関節数が変わったとき、あるいは別のロボットがturtlebotに乗ったときは
https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/208
や
https://github.com/jsk-enshu/robot-programming/issues/162
を使ってもっと綺麗にかけるといいですね。 @k-okada 