### PR TITLE
use anon rviz nodename to prevent ns collision

### DIFF
--- a/dxl_armed_turtlebot/launch/dxl_armed_turtlebot_bringup.launch
+++ b/dxl_armed_turtlebot/launch/dxl_armed_turtlebot_bringup.launch
@@ -18,7 +18,7 @@
   <include file="$(find dxl_armed_turtlebot)/launch/turtlebot_joystick_teleop.launch"
            if="$(arg RUN_PS3JOY)"/>
   <!-- <include file="$(find turtlebot_rviz_launchers)/launch/view_robot.launch"/> -->
-  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find turtlebot_rviz_launchers)/rviz/robot.rviz" respawn="true"
+  <node name="$(anon rviz)" pkg="rviz" type="rviz" args="-d $(find turtlebot_rviz_launchers)/rviz/robot.rviz" respawn="true"
         if="$(arg RUN_RVIZ)"/>
   <!--   アームの起動 -->
   <include file="$(find dynamixel_7dof_arm)/launch/dynamixel_7dof_arm_bringup.launch"/>


### PR DESCRIPTION
we can launch rviz with anonymous name.