### PR TITLE
Add 2D slam Cartographer for turtlebot navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ $ source /opt/ros/indigo/setup.bash
 $ mkdir -p ~/catkin_ws/src
 $ cd ~/catkin_ws   
 $ wstool init src
-$ wstool set robot-programming https://github.com/jsk-enshu/robot-programming --git -t src
-$ wstool set dynamixel_urdf    https://github.com/jsk-enshu/dynamixel_urdf    --git -t src
+$ wstool set robot-programming https://github.com/jsk-enshu/robot-programming --git -u -t src
+$ wstool merge -t src src/robot-programming/enshu.rosinstall
 $ wstool update -t src
 $ rosdep update                                                                                          
 $ rosdep install --from-paths src --ignore-src -y -r                                                                 

--- a/dxl_armed_turtlebot/package.xml
+++ b/dxl_armed_turtlebot/package.xml
@@ -56,4 +56,6 @@
   <run_depend>teleop_twist_keyboard</run_depend>
   <run_depend>roseus_tutorials</run_depend>
   <run_depend>slam_karto</run_depend>
+  <run_depend>cartographer_ros</run_depend>
+  <run_depend>cartographer_rviz</run_depend>
 </package>

--- a/enshu.rosinstall
+++ b/enshu.rosinstall
@@ -4,3 +4,6 @@
 - git:
     local-name: robot-programming
     uri: https://github.com/jsk-enshu/robot-programming
+- git:
+    local-name: cartographer_turtlebot
+    uri: https://github.com/googlecartographer/cartographer_turtlebot.git


### PR DESCRIPTION
Better 2D slam than gmapping or karto_slam:

1. add cartographer_ros as default run_depned
2. add repository cartographer_turtlebot in .rosinstall
3. modify the README.md for 2
