### PR TITLE
fix frame_id

### DIFF
--- a/dxl_armed_turtlebot/README.md
+++ b/dxl_armed_turtlebot/README.md
@@ -64,7 +64,7 @@ gazebo内でも実機と同様にcheckerboardを検出することができる
 
 まず、checkerboader_detectorを起動しましょう:
 ```
-$ roslaunch roseus_tutorials checkerboard-detector.launch rect0_size_x:=0.02 rect0_size_y:=0.02 grid0_size_x:=7 grid0_size_y:=4 translation0:="0 0 0" image:=image_raw  group:=/camera/rgb frame_id:=camera_rgb_frame
+$ roslaunch roseus_tutorials checkerboard-detector.launch rect0_size_x:=0.02 rect0_size_y:=0.02 grid0_size_x:=7 grid0_size_y:=4 translation0:="0 0 0" image:=image_raw  group:=/camera/rgb frame_id:=camera_rgb_optical_frame
 ```
 
 


### PR DESCRIPTION
```
 ROS_NAMESPACE=/camera/rgb rosrun checkerard_detector objectdetection_tf_publisher.py _use_simple_tf:=true
```
とするとわかるのですが，間違えではないかとおもいます．