### PR TITLE
[Melodic] linux_peripheral_interfacesをソースからインストールする

### DIFF
--- a/.rosinstall.melodic
+++ b/.rosinstall.melodic
@@ -11,6 +11,9 @@
     local-name: kobuki_desktop
     uri: https://github.com/yujinrobot/kobuki_desktop
 - git:
+    local-name: linux_peripheral_interfaces
+    uri: https://github.com/ros-drivers/linux_peripheral_interfaces.git
+- git:
     local-name: turtlebot
     uri: https://github.com/turtlebot/turtlebot
 - git:

--- a/turtleboteus/package.xml
+++ b/turtleboteus/package.xml
@@ -11,14 +11,12 @@
   <build_depend>kobuki_msgs</build_depend>
   <build_depend>control_msgs</build_depend>
   <build_depend>move_base_msgs</build_depend>
-  <build_depend>linux_peripheral_interfaces</build_depend>
   <build_depend>pr2eus</build_depend>
   <build_depend>rostest</build_depend>
 
   <run_depend>kobuki_msgs</run_depend>
   <run_depend>control_msgs</run_depend>
   <run_depend>move_base_msgs</run_depend>
-  <run_depend>linux_peripheral_interfaces</run_depend>
   <run_depend>pr2eus</run_depend>
   <run_depend>rostest</run_depend>
 </package>


### PR DESCRIPTION
`minimal.launch`であがるnodeの中に、リリースされておらず、.rosinstall.melodic に含まれてないものがありました。
https://github.com/turtlebot/turtlebot/blob/kinetic/turtlebot_bringup/launch/includes/netbook.launch.xml#L6-L8
で呼ばれる以下です。
https://github.com/ros-drivers/linux_peripheral_interfaces/issues/13
（仮に現状のままでも、roslaunch minimal.launchでエラーはでますが、演習で行う動作自体は一応問題なく動かすことはできるようです。）

更新した.rosinstallで、catkin workspaceを作って、問題なく動くことを確認しました。

また、以下のエラーが出るので、`linux_peripheral_interfaces`をturtuleboteusのpackage.xmlから消しました。依存関係は、
https://github.com/turtlebot/turtlebot/blob/kinetic/turtlebot_bringup/package.xml#L32
で正しく書いてあるので、turtuleboteusには書かなくて良いように思います。
```
WARNING: package "turtleboteus" should not depend on metapackage "linux_peripheral_interfaces" but on its packages instead
WARNING: package "turtleboteus" should not depend on metapackage "linux_peripheral_interfaces" but on its packages instead
[build] Package table is up to date.
Abandoned <<< turtleboteus                              [ Depends on unknown jobs: linux_peripheral_interfaces ]
Abandoned <<< dxl_armed_turtlebot                       [ Depends on unknown jobs: linux_peripheral_interfaces ]
Abandoned <<< daisya_euslisp_tutorials                  [ Depends on unknown jobs: linux_peripheral_interfaces ]
```