### PR TITLE
[Melodic] jsk_toolsへの依存を追加

### DIFF
--- a/dxl_armed_turtlebot/package.xml
+++ b/dxl_armed_turtlebot/package.xml
@@ -27,6 +27,7 @@
   <run_depend>joy</run_depend>
   <run_depend>jsk_perception</run_depend>
   <run_depend>jsk_pcl_ros</run_depend>
+  <run_depend>jsk_tools</run_depend>
   <run_depend>joystick_drivers</run_depend>
   <run_depend>kobuki_dashboard</run_depend>
   <run_depend>kobuki_gazebo</run_depend>


### PR DESCRIPTION
演習資料の初回の冒頭で、
```bash
sudo apt-get install ros-kinetic-jsk-tools # 今年も書くならmelodic
echo "source `rospack find jsk_tools`/src/bashrc.ros" >> ~/.bashrc
```
をさせて、`rossetmaster`, `rossetip`を確認させています。

.bashrcに追記させる二行目のほうは、env-hookになっていて必要ないので、資料からは消して良いとして、
そもそも apt-get installをする一行目も、package.xmlに追加してしまえば、rosdep install （これはロボットシステムの授業で実行済みであることが期待される？）で、勝手にjsk_toolsが入ってくれるので、
二行とも消して良くなって、演習で本題に早く進めるようになりそうです。
