### PR TITLE
[Melodic] turtlebot_interactionsへの依存を追加

### DIFF
--- a/.rosinstall.melodic
+++ b/.rosinstall.melodic
@@ -20,5 +20,8 @@
     local-name: turtlebot_apps
     uri: https://github.com/turtlebot/turtlebot_apps
 - git:
+    local-name: turtlebot_interactions
+    uri: https://github.com/turtlebot/turtlebot_interactions.git
+- git:
     local-name: turtlebot_msgs
     uri: https://github.com/turtlebot/turtlebot_msgs


### PR DESCRIPTION
第二回演習「3.3 インタラクティブマーカによる操縦」で、
```
roslaunch turtlebot_interactive_markers interactive_markers.launch
roslaunch turtlebot_rviz_launchers view_robot.launch
```
をしています。
これらのプログラムは、aptでリリースされておらず、講義・演習の手順に沿ったPC環境では、プログラムが見つかりません。なので、.rosinstallに追加する必要があります。
（もしくは、これは演習の他の部分に影響しないようなので、削ってしまうというという選択もありでしょうか。）