### PR TITLE
:reset-poseでangle-vectorが返ってくるようにする

### DIFF
--- a/dynamixel_7dof_arm/euslisp/dxl-7dof-arm-robot.l
+++ b/dynamixel_7dof_arm/euslisp/dxl-7dof-arm-robot.l
@@ -384,13 +384,15 @@
    "Reset pose."
    (let ()
      (send self :angle-vector (float-vector 0.0 0.0 -90.0 0.0 90.0 0.0))
-     (send (send self :gripper_joint) :joint-angle 0)))
+     (send (send self :gripper_joint) :joint-angle 0)
+     (send self :angle-vector)))
   (:reset-pose2
    ()
    "Reset pose2."
    (let ()
      (send self :angle-vector (float-vector 0.0 150.0 -90.0 0.0 90.0 0.0))
-     (send (send self :gripper_joint) :joint-angle 0)))
+     (send (send self :gripper_joint) :joint-angle 0)
+     (send self :angle-vector)))
   (:tuckarm-pose
    ()
    "Folding arm pose."

--- a/dynamixel_7dof_arm/euslisp/dxl-7dof-arm-robot.l
+++ b/dynamixel_7dof_arm/euslisp/dxl-7dof-arm-robot.l
@@ -346,13 +346,13 @@
        (send (elt ln i) :assoc (elt ln (1+ i))))
      ln))
   ;; joints
-  (:arm_joint1 () jc0)
-  (:arm_joint2 () jc1)
-  (:arm_joint3 () jc2)
-  (:arm_joint4 () jc3)
-  (:arm_joint5 () jc4)
-  (:arm_joint6 () jc5)
-  (:gripper_joint () gripper_jc)
+  (:arm_joint1 (&rest args) (user::forward-message-to jc0 args))
+  (:arm_joint2 (&rest args) (user::forward-message-to jc1 args))
+  (:arm_joint3 (&rest args) (user::forward-message-to jc2 args))
+  (:arm_joint4 (&rest args) (user::forward-message-to jc3 args))
+  (:arm_joint5 (&rest args) (user::forward-message-to jc4 args))
+  (:arm_joint6 (&rest args) (user::forward-message-to jc5 args))
+  (:gripper_joint (&rest args) (user::forward-message-to gripper_jc args))
 
   ;; limbs
   (:arm (&rest args)
@@ -383,13 +383,13 @@
    ()
    "Reset pose."
    (send self :angle-vector (float-vector 0.0 0.0 -90.0 0.0 90.0 0.0))
-   (send (send self :gripper_joint) :joint-angle 0)
+   (send self :gripper_joint :joint-angle 0)
    (send self :angle-vector))
   (:reset-pose2
    ()
    "Reset pose2."
    (send self :angle-vector (float-vector 0.0 150.0 -90.0 0.0 90.0 0.0))
-   (send (send self :gripper_joint) :joint-angle 0)
+   (send self :gripper_joint :joint-angle 0)
    (send self :angle-vector))
   (:tuckarm-pose
    ()

--- a/dynamixel_7dof_arm/euslisp/dxl-7dof-arm-robot.l
+++ b/dynamixel_7dof_arm/euslisp/dxl-7dof-arm-robot.l
@@ -382,17 +382,15 @@
   (:reset-pose
    ()
    "Reset pose."
-   (let ()
-     (send self :angle-vector (float-vector 0.0 0.0 -90.0 0.0 90.0 0.0))
-     (send (send self :gripper_joint) :joint-angle 0)
-     (send self :angle-vector)))
+   (send self :angle-vector (float-vector 0.0 0.0 -90.0 0.0 90.0 0.0))
+   (send (send self :gripper_joint) :joint-angle 0)
+   (send self :angle-vector))
   (:reset-pose2
    ()
    "Reset pose2."
-   (let ()
-     (send self :angle-vector (float-vector 0.0 150.0 -90.0 0.0 90.0 0.0))
-     (send (send self :gripper_joint) :joint-angle 0)
-     (send self :angle-vector)))
+   (send self :angle-vector (float-vector 0.0 150.0 -90.0 0.0 90.0 0.0))
+   (send (send self :gripper_joint) :joint-angle 0)
+   (send self :angle-vector))
   (:tuckarm-pose
    ()
    "Folding arm pose."


### PR DESCRIPTION
`(send *dxl-armed-turtlebot* :reset-pose)` の返り値が0だったのを、angle-vectorが返ってくるように修正しました。

```
(send *ri* :angle-vector (send *dxl-armed-turtlebot* :reset-pose))
```
のようにできるようになります。。

:hoge-pose メソッドでangle-vectorが返ってくる仕様は、urdfやwrlからcolladaを経て変換されるロボットモデルでは一般的です:
https://github.com/jsk-ros-pkg/jsk_model_tools/blob/master/euscollada/src/collada2eus_old.cpp#L1207-L1213