### PR TITLE
実機とgazeboの両方で，rqtのテレオペGUIを使えるようにする

### DIFF
--- a/dxl_armed_turtlebot/launch/turtlebot_joystick_teleop.launch
+++ b/dxl_armed_turtlebot/launch/turtlebot_joystick_teleop.launch
@@ -1,4 +1,7 @@
 <launch>
+  <node name="cmd_vel_renamer" pkg="topic_tools" type="relay"
+        args=" /cmd_vel /cmd_vel_mux/input/teleop" />
+
   <arg name="joy_dev" default="/dev/input/js0" doc="device file name for joystick"/>
   <!--  smooths inputs from cmd_vel_mux/input/teleop_raw to cmd_vel_mux/input/teleop -->
   <include file="$(find turtlebot_teleop)/launch/includes/velocity_smoother.launch.xml"/>


### PR DESCRIPTION
2019/9/30のロボットシステム資料にある
```
rqt --perspective-file enshu.perspective
```
を実機とgazeboの両方で動くようにしたいです．
（origin/masterのままでは，実機では動かないです．）

ちゃんとわかっているわけではないのですが，
gazebo: `/cmd_vel`
実機: `/cmd_vel_mux/input/teleop`
が対応していて，これをrelayしたところ，実機でも動くことを確認できました．


もう一つの候補は，以下のようにgazeboを実機に合わせることですが（こちらも，実機とgazebo両方で動作確認済み），
こうするとロボットシステム講義資料にあるpythonで/cmd_velをpublishするプログラムが動かなくなるので，このPRの方が良い気がしています．
https://github.com/jsk-enshu/robot-programming/compare/master...mmurooka:real-gazebo-teleop-common-fix-gazebo


