### PR TITLE
revert cmd_vel_renamer, so that we can send /cmd_vel topic, c.f #407

### DIFF
--- a/dxl_armed_turtlebot/launch/dxl_armed_turtlebot_gazebo.launch
+++ b/dxl_armed_turtlebot/launch/dxl_armed_turtlebot_gazebo.launch
@@ -12,6 +12,8 @@
   <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
     <param name="publish_frequency" type="double" value="30.0" />
   </node>
+  <node name="cmd_vel_renamer" pkg="topic_tools" type="relay"
+        args=" /cmd_vel /mobile_base/commands/velocity" />
   <node name="depth_renamer" pkg="topic_tools" type="relay"
         args=" /camera/depth/points /camera/depth_registered/points" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find dxl_armed_turtlebot)/config/dxl_armed_turtlebot.rviz"/>

--- a/dxl_armed_turtlebot/launch/dxl_armed_turtlebot_gazebo.launch
+++ b/dxl_armed_turtlebot/launch/dxl_armed_turtlebot_gazebo.launch
@@ -13,7 +13,7 @@
     <param name="publish_frequency" type="double" value="30.0" />
   </node>
   <node name="cmd_vel_renamer" pkg="topic_tools" type="relay"
-        args=" /cmd_vel /mobile_base/commands/velocity" />
+        args=" /cmd_vel /cmd_vel_mux/input/teleop" />
   <node name="depth_renamer" pkg="topic_tools" type="relay"
         args=" /camera/depth/points /camera/depth_registered/points" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find dxl_armed_turtlebot)/config/dxl_armed_turtlebot.rviz"/>


### PR DESCRIPTION
@kindsenior 
#407 の https://github.com/jsk-enshu/robot-programming/pull/407/files#diff-08e0e0faabe14a0737b8228dc366c0cdb979c4bba52880aa00c60c593ab195abL15-L16 で
`/cmd_vel` を `/mobile_base/commands/velocity` の別名として使うコードを消しているんだけど，これ必要かな？

世の中的には `cmd_vel` が一般的で，`teleop_twist_keyboard.py` もデフォルトこれなので，消す必要ないと思うんですがいかがでしょうか？
もし，enshuロボットは，`/mobile_base/commands/velocity` で行くんだということだとすると，
https://github.com/jsk-enshu/robot-programming/blob/0c6f524d5cb296b1df2985dc127ada9e1e4793ad/dxl_armed_turtlebot/launch/enshu.perspective#L34-L37

の部分を変更する必要があるかとおもいます．
もしこれで良ければ，マージして，以下に善後策を伝えていただければと思います．
#416 #417 

%新しくコードを追加する前に Travisなり GithubAction なり使えるように戻すべきでした．．．