### PR TITLE
revert cmd_vel_renamer, rename cmd_ve_mux and launch rename in anon

### DIFF
--- a/dxl_armed_turtlebot/launch/dxl_armed_turtlebot_gazebo.launch
+++ b/dxl_armed_turtlebot/launch/dxl_armed_turtlebot_gazebo.launch
@@ -12,6 +12,8 @@
   <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
     <param name="publish_frequency" type="double" value="30.0" />
   </node>
+  <node name="cmd_vel_renamer" pkg="topic_tools" type="relay"
+        args=" /cmd_vel /mobile_base/commands/velocity" />
   <node name="depth_renamer" pkg="topic_tools" type="relay"
         args=" /camera/depth/points /camera/depth_registered/points" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find dxl_armed_turtlebot)/config/dxl_armed_turtlebot.rviz"/>

--- a/dxl_armed_turtlebot/launch/dxl_armed_turtlebot_gazebo.launch
+++ b/dxl_armed_turtlebot/launch/dxl_armed_turtlebot_gazebo.launch
@@ -13,7 +13,7 @@
     <param name="publish_frequency" type="double" value="30.0" />
   </node>
   <node name="cmd_vel_renamer" pkg="topic_tools" type="relay"
-        args=" /cmd_vel /mobile_base/commands/velocity" />
+        args=" /cmd_vel /cmd_vel_mux/input/teleop" />
   <node name="depth_renamer" pkg="topic_tools" type="relay"
         args=" /camera/depth/points /camera/depth_registered/points" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find dxl_armed_turtlebot)/config/dxl_armed_turtlebot.rviz"/>

--- a/dxl_armed_turtlebot/launch/turtlebot_joystick_teleop.launch
+++ b/dxl_armed_turtlebot/launch/turtlebot_joystick_teleop.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node name="cmd_vel_renamer" pkg="topic_tools" type="relay"
+  <node name="$(anon cmd_vel_renamer)" pkg="topic_tools" type="relay"
         args=" /cmd_vel /cmd_vel_mux/input/teleop" />
 
   <arg name="joy_dev" default="/dev/input/js0" doc="device file name for joystick"/>


### PR DESCRIPTION
#418 に対する修正です

まとめると
- [dxl_armed_turtlebot_gazebo.launch](https://github.com/jsk-enshu/robot-programming/blob/master/dxl_armed_turtlebot/launch/dxl_armed_turtlebot_gazebo.launch)でcmd_velをrename & rename先を/cmd_vel_mux/input/teleopにする
[dfb52b7](https://github.com/jsk-enshu/robot-programming/pull/418/commits/dfb52b7c5a74e79000e8b886c864ce61ba548ff4)
[5bc2ef8](https://github.com/jsk-enshu/robot-programming/pull/418/commits/5bc2ef80a965a56dfda29658e951b3e2f08b441e)
- [turtlebot_joystick_teleop.launch](https://github.com/jsk-enshu/robot-programming/blob/master/dxl_armed_turtlebot/launch/turtlebot_joystick_teleop.launch)
[1e6a31d](https://github.com/jsk-enshu/robot-programming/commit/1e6a31dcb943a6489a08f27c526a3e26d633b63a)でrenamerをanonで起動する
ようにしました
