### PR TITLE
support ps3joy USB connection

### DIFF
--- a/.rosinstall.melodic
+++ b/.rosinstall.melodic
@@ -39,3 +39,6 @@
     local-name: turtlebot_msgs
     uri: https://github.com/turtlebot/turtlebot_msgs.git
     version: 2.2.1
+- git:
+    local-name: joy
+    uri: https://github.com/ros-drivers/joystick_drivers.git

--- a/dxl_armed_turtlebot/launch/turtlebot_joystick_teleop.launch
+++ b/dxl_armed_turtlebot/launch/turtlebot_joystick_teleop.launch
@@ -3,6 +3,7 @@
         args=" /cmd_vel /cmd_vel_mux/input/teleop" />
 
   <arg name="joy_dev" default="/dev/input/js0" doc="device file name for joystick"/>
+  <arg name="joy_bluetooth" default="true" doc="joystick connection is bluetooth or not (wired)"/>
   <!--  smooths inputs from cmd_vel_mux/input/teleop_raw to cmd_vel_mux/input/teleop -->
   <include file="$(find turtlebot_teleop)/launch/includes/velocity_smoother.launch.xml"/>
 
@@ -17,6 +18,15 @@
 
   <node pkg="joy" type="joy_node" name="joystick">
     <param name="dev" type="string" value="$(arg joy_dev)" />
+    <remap unless="$(arg joy_bluetooth)" from="joy" to="joy_ps3" />
   </node>
+
+  <group unless="$(arg joy_bluetooth)">
+    <node name="joy_remap" pkg="joy" type="joy_remap.py" output="screen" >
+      <remap from="joy_in" to="joy_ps3" />
+      <remap from="joy_out" to="joy" />
+      <rosparam command="load" file="$(find joy)/config/ps3joy.yaml" />
+    </node>
+  </group>
 
 </launch>


### PR DESCRIPTION
#432 に関するPRです．

2022年度冬学期演習資料のA.1.3において，ジョイコンをBluetooth接続ではなくUSB接続した場合にも以下のlaunchの仕方で動作するようにしました．

```bash
$ roslaunch dxl_armed_turtlebot turtlebot_joystick_teleop.launch                 # Bluetooth
$ roslaunch dxl_armed_turtlebot turtlebot_joystick_teleop.launch joy_bluetooth:=false # USB
```

ファイル内で指定しているyamlファイルは本家のリポジトリにはマージされていますが，まだaptでリリースされていないので`joy`をローカルでビルドするようにしています．

melodic 1.14.13.とタートルボット実機で正しく動作することを確認しました．
