### PR TITLE
Noetic in Nov before Day3

### DIFF
--- a/.rosinstall.noetic
+++ b/.rosinstall.noetic
@@ -74,3 +74,7 @@
     # uri: https://github.com/jsk-ros-pkg/jsk_roseus.git
     uri: https://github.com/k-okada/jsk_roseus.git
     version: set-log-level-to-error
+- git:
+    local-name: ros_controllers
+    uri: https://github.com/ros-controls/ros_controllers.git
+    version: 0.20.0 # after this version, ros_control does not publish /motor1/position based on /position_trajectory_controller/command from /rqt_joint_trajectory_controller because of the same warning https://github.com/ros-controls/ros_controllers/issues/291

--- a/mechatrobot/launch/sample_face_detect.launch
+++ b/mechatrobot/launch/sample_face_detect.launch
@@ -10,6 +10,9 @@
   <include file="$(find opencv_apps)/launch/face_detection.launch">
     <arg name="image" value="/usb_cam/image_raw"/>
     <arg name="debug_view" value="$(arg debug_view)"/>
+    <!-- maybe it is correct to setting use_opencv4 arg but it does not work in face_detection.launch -->
+    <arg name="face_cascade_name" value="/usr/share/opencv4/haarcascades/haarcascade_frontalface_alt.xml" />
+    <arg name="eyes_cascade_name" value="/usr/share/opencv4/haarcascades/haarcascade_eye_tree_eyeglasses.xml" />
   </include>
     
 </launch>

--- a/mechatrobot/scripts/motor-command-by-face.py
+++ b/mechatrobot/scripts/motor-command-by-face.py
@@ -5,7 +5,7 @@ from opencv_apps.msg import FaceArrayStamped
 from std_msgs.msg import Int64
 
 image_size = [640, 480] # pixel
-image_center = list(map(lambda x: x/2, image_size))
+image_center = list([x/2 for x in image_size])
 motor_angle = 0 # [deg]
 
 def face_detection_cb(msg):
@@ -29,13 +29,13 @@ def face_detection_cb(msg):
         motor_command_msg.data = motor_angle
 
         # print
-        print "face_pos(x, y): ({} {})".format(face_pos[0], face_pos[1])
-        print "/motor1/command: {}\n".format(motor_command_msg.data)
+        print("face_pos(x, y): ({} {})".format(face_pos[0], face_pos[1]))
+        print("/motor1/command: {}\n".format(motor_command_msg.data))
 
         # publish
         pub.publish(motor_command_msg)
     else:
-        print "no faces"
+        print("no faces")
     
         
 def main():


### PR DESCRIPTION
以下の3点の変更
- python3への対応
- (temporarily) ros_controllersのrevert．[ros_controllers#291](https://github.com/ros-controls/ros_controllers/issues/291)と同様にrqt_joint_trajectoryから受けた/position_trajectory_controller/commandに応じて/motor1/positionをpublishできない
- (temporarily) face_detection.launchでuse_opencv4:=true use_opencv3:=trueが機能しない [opencv_apps#134](https://github.com/ros-perception/opencv_apps/issues/134)